### PR TITLE
Normalize request path during comparison

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   "dependencies": {
     "babel-runtime": "^6.11.6",
     "debug": "^2.0.0",
-    "js-string-escape": "~1.0.0"
+    "js-string-escape": "~1.0.0",
+    "normalize-url": "^1.6.0"
   },
   "devDependencies": {
     "async": "^0.9.0",

--- a/test/fixtures/example.com-3002/query_2
+++ b/test/fixtures/example.com-3002/query_2
@@ -1,4 +1,4 @@
-GET /query?param=2
+GET /query?param=2&param2=
 
 HTTP/1.1 200 OK
 Content-Type: text/html

--- a/test/replay_test.js
+++ b/test/replay_test.js
@@ -90,6 +90,7 @@ describe('Replay', function() {
   describe('matching on query strings', function() {
     let response1;
     let response2;
+    let response3;
 
     before(function(done) {
       HTTP.get({ hostname: 'example.com', port: INACTIVE_PORT, path: '/query?param=1' })
@@ -105,7 +106,8 @@ describe('Replay', function() {
     });
 
     before(function(done) {
-      HTTP.get({ hostname: 'example.com', port: INACTIVE_PORT, path: '/query?param=2' })
+      // ordered params
+      HTTP.get({ hostname: 'example.com', port: INACTIVE_PORT, path: '/query?param=2&param2=' })
         .on('response', function(_) {
           response2 = _;
           response2.body = '';
@@ -117,10 +119,25 @@ describe('Replay', function() {
         .on('error', done);
     });
 
+    before(function(done) {
+      // unordered params
+      HTTP.get({ hostname: 'example.com', port: INACTIVE_PORT, path: '/query?param2=&param=2' })
+        .on('response', function(_) {
+          response3 = _;
+          response3.body = '';
+          response3.on('data', function(chunk) {
+            response3.body += chunk;
+          });
+          response3.on('end', done);
+        })
+        .on('error', done);
+    });
+
     it('should select the correct fixture', function() {
       // HTTP body contains tailing line feeds, use trim to get rid of them
       assert.equal(response1.body.trim(), '1');
       assert.equal(response2.body.trim(), '2');
+      assert.equal(response3.body.trim(), '2');
     });
   });
 


### PR DESCRIPTION
Request matching should not relay on the order of query parameters.
